### PR TITLE
0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * `User` now implement `PrivateChat`
 * `TextMentionMessageEntity` now accept `PrivateChat` instead of `User` in main constructor
     * `TextMentionMessageEntity` now contains not user, but contains `PrivateChat`
+    * Fixeed: `TextMentionMessageEntity#asHtmlSource` previously worked incorrect
 
 ## 0.19.0 ImplicitReflection removing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
     * `createFormattedText` method now accept `List<TextSource>`
     * `createHtmlText` method now accept `List<TextSource>`
     * `createMarkdownText` method now accept `List<TextSource>`
+    * A lot of `TextSource` implementors was added. More info [here](src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/)
+        * All `MessageEntity` implementations now are using new `TextSource` analogues as delegates
 
 ## 0.19.0 ImplicitReflection removing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 * `TextMentionMessageEntity` now accept `PrivateChat` instead of `User` in main constructor
     * `TextMentionMessageEntity` now contains not user, but contains `PrivateChat`
     * Fixeed: `TextMentionMessageEntity#asHtmlSource` previously worked incorrect
+* Abstraction `TextSource`
+    * `MessageEntity` now extends `TextSource`
+    * `createFormattedText` method now accept `List<TextSource>`
+    * `createHtmlText` method now accept `List<TextSource>`
+    * `createMarkdownText` method now accept `List<TextSource>`
 
 ## 0.19.0 ImplicitReflection removing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * `User` now have no field `userLocale`
     * For `Java` there is `User#javaLocale` extension function, which will give an old locale work way
 
+### 0.20.1
+
 ## 0.19.0 ImplicitReflection removing
 
 * Total rework of serialization for requests. Now all `SimpleRequest` children have:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 0.20.1
 
+* `User` now implement `PrivateChat`
+* `TextMentionMessageEntity` now accept `PrivateChat` instead of `User` in main constructor
+    * `TextMentionMessageEntity` now contains not user, but contains `PrivateChat`
+
 ## 0.19.0 ImplicitReflection removing
 
 * Total rework of serialization for requests. Now all `SimpleRequest` children have:

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id "org.jetbrains.kotlin.plugin.serialization" version "$kotlin_version"
 }
 
-project.version = "0.20.0"
+project.version = "0.20.1"
 project.group = "com.github.insanusmokrassar"
 
 apply from: "publish.gradle"

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/CommonAbstracts/TextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/CommonAbstracts/TextSource.kt
@@ -1,0 +1,6 @@
+package com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts
+
+interface TextSource {
+    val asMarkdownSource: String
+    val asHtmlSource: String
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/BoldTextMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/BoldTextMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.BoldTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.boldHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.boldMarkdown
 
@@ -7,7 +9,4 @@ data class BoldTextMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.boldMarkdown()
-    override val asHtmlSource: String = sourceString.boldHTML()
-}
+) : MessageEntity, TextSource by BoldTextSource(sourceString)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/BotCommandMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/BotCommandMessageEntity.kt
@@ -1,19 +1,16 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.BotCommandTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.commandHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.commandMarkdown
-
-private val commandRegex = Regex("[/!][^@\\s]*")
 
 data class BotCommandMessageEntity(
     override val offset: Int,
     override val length: Int,
-    override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.commandMarkdown()
-    override val asHtmlSource: String = sourceString.commandHTML()
-
-    val command: String by lazy {
-        commandRegex.find(sourceString) ?.value ?.substring(1) ?: sourceString.substring(1)// skip first symbol like "/" or "!"
-    }
+    override val sourceString: String,
+    private val botCommandTextSource: BotCommandTextSource = BotCommandTextSource(sourceString)
+) : MessageEntity, TextSource by botCommandTextSource {
+    val command: String
+        get() = botCommandTextSource.command
 }

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/CodeTextMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/CodeTextMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.CodeTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.codeHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.codeMarkdown
 
@@ -7,7 +9,4 @@ data class CodeTextMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.codeMarkdown()
-    override val asHtmlSource: String = sourceString.codeHTML()
-}
+) : MessageEntity, TextSource by CodeTextSource(sourceString)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/EMailMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/EMailMessageEntity.kt
@@ -1,13 +1,12 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.EMailTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.emailHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.emailMarkdown
 
-class EMailMessageEntity(
+data class EMailMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.emailMarkdown()
-    override val asHtmlSource: String = sourceString.emailHTML()
-}
+) : MessageEntity, TextSource by EMailTextSource(sourceString)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/HashTagMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/HashTagMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.HashTagTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.hashTagHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.hashTagMarkdown
 
@@ -7,7 +9,4 @@ data class HashTagMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.hashTagMarkdown()
-    override val asHtmlSource: String = sourceString.hashTagHTML()
-}
+) : MessageEntity, TextSource by HashTagTextSource(sourceString)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/ItalicTextMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/ItalicTextMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.ItalicTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.italicHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.italicMarkdown
 
@@ -7,7 +9,4 @@ data class ItalicTextMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.italicMarkdown()
-    override val asHtmlSource: String = sourceString.italicHTML()
-}
+) : MessageEntity, TextSource by ItalicTextSource(sourceString)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/MentionMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/MentionMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.MentionTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionMarkdown
 
@@ -7,7 +9,4 @@ class MentionMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.mentionMarkdown()
-    override val asHtmlSource: String = sourceString.mentionHTML()
-}
+) : MessageEntity, TextSource by MentionTextSource(sourceString)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/MessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/MessageEntity.kt
@@ -1,10 +1,9 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
-interface MessageEntity {
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+
+interface MessageEntity : TextSource {
     val offset: Int
     val length: Int
     val sourceString: String
-    
-    val asMarkdownSource: String
-    val asHtmlSource: String
 }

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/PhoneNumberMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/PhoneNumberMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.PhoneNumberTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.phoneHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.phoneMarkdown
 
@@ -7,7 +9,4 @@ data class PhoneNumberMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.phoneMarkdown()
-    override val asHtmlSource: String = sourceString.phoneHTML()
-}
+) : MessageEntity, TextSource by PhoneNumberTextSource(sourceString)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/PreTextMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/PreTextMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.PreTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.preHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.preMarkdown
 
@@ -7,7 +9,4 @@ data class PreTextMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.preMarkdown()
-    override val asHtmlSource: String = sourceString.preHTML()
-}
+) : MessageEntity, TextSource by PreTextSource(sourceString)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/RegularTextMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/RegularTextMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.RegularTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.extensions.toHtml
 import com.github.insanusmokrassar.TelegramBotAPI.utils.extensions.toMarkdown
 
@@ -7,7 +9,4 @@ data class RegularTextMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.toMarkdown()
-    override val asHtmlSource: String = sourceString.toHtml()
-}
+) : MessageEntity, TextSource by RegularTextSource(sourceString)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/TextLinkMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/TextLinkMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.TextLinkTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.linkHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.linkMarkdown
 
@@ -8,7 +10,4 @@ data class TextLinkMessageEntity(
     override val length: Int,
     override val sourceString: String,
     val url: String
-) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.linkMarkdown(url)
-    override val asHtmlSource: String = sourceString.linkHTML(url)
-}
+) : MessageEntity, TextSource by TextLinkTextSource(sourceString, url)

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/TextMentionMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/TextMentionMessageEntity.kt
@@ -2,6 +2,7 @@ package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
 import com.github.insanusmokrassar.TelegramBotAPI.types.User
 import com.github.insanusmokrassar.TelegramBotAPI.types.chat.abstracts.PrivateChat
+import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionMarkdown
 
 class TextMentionMessageEntity(
@@ -19,5 +20,5 @@ class TextMentionMessageEntity(
     ) : this(offset, length, sourceString, user as PrivateChat)
 
     override val asMarkdownSource: String = sourceString.mentionMarkdown(privateChat.id)
-    override val asHtmlSource: String = sourceString.mentionMarkdown(privateChat.id)
+    override val asHtmlSource: String = sourceString.mentionHTML(privateChat.id)
 }

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/TextMentionMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/TextMentionMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.TextMentionTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.types.User
 import com.github.insanusmokrassar.TelegramBotAPI.types.chat.abstracts.PrivateChat
 import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionHTML
@@ -10,7 +12,7 @@ class TextMentionMessageEntity(
     override val length: Int,
     override val sourceString: String,
     val privateChat: PrivateChat
-) : MessageEntity {
+) : MessageEntity, TextSource by TextMentionTextSource(sourceString, privateChat) {
     @Deprecated("Deprecated due to the fact that there is more common constructor")
     constructor(
         offset: Int,
@@ -18,7 +20,4 @@ class TextMentionMessageEntity(
         sourceString: String,
         user: User
     ) : this(offset, length, sourceString, user as PrivateChat)
-
-    override val asMarkdownSource: String = sourceString.mentionMarkdown(privateChat.id)
-    override val asHtmlSource: String = sourceString.mentionHTML(privateChat.id)
 }

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/TextMentionMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/TextMentionMessageEntity.kt
@@ -1,14 +1,23 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
 import com.github.insanusmokrassar.TelegramBotAPI.types.User
+import com.github.insanusmokrassar.TelegramBotAPI.types.chat.abstracts.PrivateChat
 import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionMarkdown
 
 class TextMentionMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String,
-    val user: User
+    val privateChat: PrivateChat
 ) : MessageEntity {
-    override val asMarkdownSource: String = sourceString.mentionMarkdown(user.id)
-    override val asHtmlSource: String = sourceString.mentionMarkdown(user.id)
+    @Deprecated("Deprecated due to the fact that there is more common constructor")
+    constructor(
+        offset: Int,
+        length: Int,
+        sourceString: String,
+        user: User
+    ) : this(offset, length, sourceString, user as PrivateChat)
+
+    override val asMarkdownSource: String = sourceString.mentionMarkdown(privateChat.id)
+    override val asHtmlSource: String = sourceString.mentionMarkdown(privateChat.id)
 }

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/URLMessageEntity.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/URLMessageEntity.kt
@@ -1,5 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity
 
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources.URLTextSource
 import com.github.insanusmokrassar.TelegramBotAPI.utils.linkHTML
 import com.github.insanusmokrassar.TelegramBotAPI.utils.linkMarkdown
 
@@ -7,9 +9,6 @@ data class URLMessageEntity(
     override val offset: Int,
     override val length: Int,
     override val sourceString: String
-) : MessageEntity{
+) : MessageEntity, TextSource by URLTextSource(sourceString) {
     val url: String = sourceString
-
-    override val asMarkdownSource: String = sourceString.linkMarkdown(url)
-    override val asHtmlSource: String = sourceString.linkHTML(url)
 }

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/BoldTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/BoldTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.boldHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.boldMarkdown
+
+class BoldTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.boldMarkdown()
+    override val asHtmlSource: String = sourceString.boldHTML()
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/BotCommandTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/BotCommandTextSource.kt
@@ -1,0 +1,18 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.commandHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.commandMarkdown
+
+private val commandRegex = Regex("[/!][^@\\s]*")
+
+class BotCommandTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.commandMarkdown()
+    override val asHtmlSource: String = sourceString.commandHTML()
+
+    val command: String by lazy {
+        commandRegex.find(sourceString) ?.value ?.substring(1) ?: sourceString.substring(1)// skip first symbol like "/" or "!"
+    }
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/CodeTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/CodeTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.codeHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.codeMarkdown
+
+class CodeTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.codeMarkdown()
+    override val asHtmlSource: String = sourceString.codeHTML()
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/EMailTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/EMailTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.emailHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.emailMarkdown
+
+class EMailTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.emailMarkdown()
+    override val asHtmlSource: String = sourceString.emailHTML()
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/HashTagTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/HashTagTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.hashTagHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.hashTagMarkdown
+
+class HashTagTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.hashTagMarkdown()
+    override val asHtmlSource: String = sourceString.hashTagHTML()
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/ItalicTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/ItalicTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.italicHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.italicMarkdown
+
+class ItalicTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.italicMarkdown()
+    override val asHtmlSource: String = sourceString.italicHTML()
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/MentionTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/MentionTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionMarkdown
+
+class MentionTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.mentionMarkdown()
+    override val asHtmlSource: String = sourceString.mentionHTML()
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/PhoneNumberTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/PhoneNumberTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.phoneHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.phoneMarkdown
+
+class PhoneNumberTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.phoneMarkdown()
+    override val asHtmlSource: String = sourceString.phoneHTML()
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/PreTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/PreTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.preHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.preMarkdown
+
+class PreTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.preMarkdown()
+    override val asHtmlSource: String = sourceString.preHTML()
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/RegularTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/RegularTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.extensions.toHtml
+import com.github.insanusmokrassar.TelegramBotAPI.utils.extensions.toMarkdown
+
+class RegularTextSource(
+    sourceString: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.toMarkdown()
+    override val asHtmlSource: String = sourceString.toHtml()
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/TextLinkTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/TextLinkTextSource.kt
@@ -1,0 +1,13 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.linkHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.linkMarkdown
+
+class TextLinkTextSource(
+    sourceString: String,
+    url: String
+) : TextSource {
+    override val asMarkdownSource: String = sourceString.linkMarkdown(url)
+    override val asHtmlSource: String = sourceString.linkHTML(url)
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/TextMentionTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/TextMentionTextSource.kt
@@ -1,0 +1,21 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.types.User
+import com.github.insanusmokrassar.TelegramBotAPI.types.chat.abstracts.PrivateChat
+import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.mentionMarkdown
+
+class TextMentionTextSource(
+    sourceString: String,
+    privateChat: PrivateChat
+) : TextSource {
+    @Deprecated("Deprecated due to the fact that there is more common constructor")
+    constructor(
+        sourceString: String,
+        user: User
+    ) : this(sourceString, user as PrivateChat)
+
+    override val asMarkdownSource: String = sourceString.mentionMarkdown(privateChat.id)
+    override val asHtmlSource: String = sourceString.mentionHTML(privateChat.id)
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/URLTextSource.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/URLTextSource.kt
@@ -1,0 +1,12 @@
+package com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.textsources
+
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
+import com.github.insanusmokrassar.TelegramBotAPI.utils.linkHTML
+import com.github.insanusmokrassar.TelegramBotAPI.utils.linkMarkdown
+
+class URLTextSource(
+    sourceString: String
+) : TextSource{
+    override val asMarkdownSource: String = sourceString.linkMarkdown(sourceString)
+    override val asHtmlSource: String = sourceString.linkHTML(sourceString)
+}

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/User.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/User.kt
@@ -1,19 +1,20 @@
 package com.github.insanusmokrassar.TelegramBotAPI.types
 
+import com.github.insanusmokrassar.TelegramBotAPI.types.chat.abstracts.PrivateChat
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class User(
-    val id: ChatId,
+    override val id: ChatId,
     @SerialName(isBotField)
     val isBot: Boolean = false,
     @SerialName(firstNameField)
-    val firstName: String,
+    override val firstName: String,
     @SerialName(lastNameField)
-    val lastName: String? = null,
+    override val lastName: String = "",
     @SerialName(usernameField)
-    val username: Username? = null,
+    override val username: Username? = null,
     @SerialName(languageCodeField)
     val languageCode: String? = null
-)
+) : PrivateChat

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/utils/Captions.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/utils/Captions.kt
@@ -1,6 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.utils
 
 import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.CaptionedInput
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
 import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.MessageEntity
 import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.RegularTextMessageEntity
 import com.github.insanusmokrassar.TelegramBotAPI.types.ParseMode.*
@@ -37,7 +38,7 @@ fun convertToFullMessageEntityList(
 }
 
 fun createFormattedText(
-    entities: List<MessageEntity>,
+    entities: List<TextSource>,
     partLength: Int = 4096,
     mode: ParseMode = MarkdownParseMode
 ): List<String> {

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/utils/HtmlCaptionSourcer.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/utils/HtmlCaptionSourcer.kt
@@ -1,6 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.utils
 
 import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.CaptionedInput
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
 import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.MessageEntity
 import com.github.insanusmokrassar.TelegramBotAPI.types.ParseMode.HTMLParseMode
 import com.github.insanusmokrassar.TelegramBotAPI.types.captionLength
@@ -8,7 +9,7 @@ import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.TextCont
 import com.github.insanusmokrassar.TelegramBotAPI.types.textLength
 
 fun createHtmlText(
-    entities: List<MessageEntity>,
+    entities: List<TextSource>,
     partLength: Int = 4096
 ): List<String> = createFormattedText(entities, partLength, HTMLParseMode)
 

--- a/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/utils/MarkdownCaptionSourcer.kt
+++ b/src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/utils/MarkdownCaptionSourcer.kt
@@ -1,6 +1,7 @@
 package com.github.insanusmokrassar.TelegramBotAPI.utils
 
 import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.CaptionedInput
+import com.github.insanusmokrassar.TelegramBotAPI.CommonAbstracts.TextSource
 import com.github.insanusmokrassar.TelegramBotAPI.types.MessageEntity.MessageEntity
 import com.github.insanusmokrassar.TelegramBotAPI.types.ParseMode.MarkdownParseMode
 import com.github.insanusmokrassar.TelegramBotAPI.types.captionLength
@@ -8,7 +9,7 @@ import com.github.insanusmokrassar.TelegramBotAPI.types.message.content.TextCont
 import com.github.insanusmokrassar.TelegramBotAPI.types.textLength
 
 fun createMarkdownText(
-    entities: List<MessageEntity>,
+    entities: List<TextSource>,
     partLength: Int = 4096
 ): List<String> = createFormattedText(entities, partLength, MarkdownParseMode)
 


### PR DESCRIPTION
* `User` now implement `PrivateChat`
* `TextMentionMessageEntity` now accept `PrivateChat` instead of `User` in main constructor
    * `TextMentionMessageEntity` now contains not user, but contains `PrivateChat`
    * Fixeed: `TextMentionMessageEntity#asHtmlSource` previously worked incorrect
* Abstraction `TextSource`
    * `MessageEntity` now extends `TextSource`
    * `createFormattedText` method now accept `List<TextSource>`
    * `createHtmlText` method now accept `List<TextSource>`
    * `createMarkdownText` method now accept `List<TextSource>`
    * A lot of `TextSource` implementors was added. More info [here](src/commonMain/kotlin/com/github/insanusmokrassar/TelegramBotAPI/types/MessageEntity/textsources/)
        * All `MessageEntity` implementations now are using new `TextSource` analogues as delegates
