### PR TITLE
Support for "migrated to supergroup" events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # TelegramBotAPI changelog
 
 ## 0.37.4
+* `Core`:
+    * New `SupergroupEvent` subtype: `MigratedToSupergroup`. This event is sent when a group is converted to a supergroup while bot is in the group.
+    * Helper extenstion functions on `ChatEvent` to cast it to `MigratedToSupergroup`.
 
 ## 0.37.3 Hotfix of 0.37.3
 

--- a/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/types/message/ChatEvents/GroupChatCreated.kt
+++ b/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/types/message/ChatEvents/GroupChatCreated.kt
@@ -1,8 +1,8 @@
 package dev.inmo.tgbotapi.types.message.ChatEvents
 
-import dev.inmo.tgbotapi.types.ChatIdentifier
+import dev.inmo.tgbotapi.types.ChatId
 import dev.inmo.tgbotapi.types.message.ChatEvents.abstracts.GroupEvent
 
 class GroupChatCreated(
-    val migratedTo: ChatIdentifier?
+    val migratedTo: ChatId?
 ): GroupEvent

--- a/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/types/message/ChatEvents/MigratedToSupergroup.kt
+++ b/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/types/message/ChatEvents/MigratedToSupergroup.kt
@@ -3,6 +3,9 @@ package dev.inmo.tgbotapi.types.message.ChatEvents
 import dev.inmo.tgbotapi.types.ChatId
 import dev.inmo.tgbotapi.types.message.ChatEvents.abstracts.SupergroupEvent
 
-class SupergroupChatCreated(
-    val migratedFrom: ChatId?
+/**
+ * This event is sent when a group is converted to a supergroup.
+ */
+class MigratedToSupergroup(
+    val migratedFrom: ChatId
 ): SupergroupEvent

--- a/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/types/message/RawMessage.kt
+++ b/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/types/message/RawMessage.kt
@@ -75,8 +75,8 @@ internal data class RawMessage(
     private val group_chat_created: Boolean = false,
     private val supergroup_chat_created: Boolean = false,
     private val channel_chat_created: Boolean = false,
-    private val migrate_to_chat_id: ChatIdentifier? = null,
-    private val migrate_from_chat_id: ChatIdentifier? = null,
+    private val migrate_to_chat_id: ChatId? = null,
+    private val migrate_from_chat_id: ChatId? = null,
     private val pinned_message: RawMessage? = null,
     private val invoice: Invoice? = null,
     private val dice: Dice? = null,
@@ -192,6 +192,9 @@ internal data class RawMessage(
                 migrate_to_chat_id
             )
             supergroup_chat_created -> SupergroupChatCreated(
+                migrate_from_chat_id
+            )
+            migrate_from_chat_id != null -> MigratedToSupergroup(
                 migrate_from_chat_id
             )
             channel_chat_created -> ChannelChatCreated()

--- a/tgbotapi.core/src/commonTest/kotlin/dev/inmo/tgbotapi/types/message/ChatEvents/MigratedToSupergroupTest.kt
+++ b/tgbotapi.core/src/commonTest/kotlin/dev/inmo/tgbotapi/types/message/ChatEvents/MigratedToSupergroupTest.kt
@@ -1,0 +1,52 @@
+package dev.inmo.tgbotapi.types.message.ChatEvents
+
+import dev.inmo.tgbotapi.TestsJsonFormat
+import dev.inmo.tgbotapi.extensions.utils.asMessageUpdate
+import dev.inmo.tgbotapi.extensions.utils.asMigratedToSupergroup
+import dev.inmo.tgbotapi.extensions.utils.asSupergroupChatCreated
+import dev.inmo.tgbotapi.extensions.utils.asSupergroupEventMessage
+import dev.inmo.tgbotapi.types.ChatId
+import dev.inmo.tgbotapi.types.update.abstracts.UpdateDeserializationStrategy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.fail
+
+
+class MigratedToSupergroupTest {
+    @Test
+    fun `MigratedToSupergroup event should be parsed`() {
+        val payload = """
+            {
+              "update_id": 42,
+              "message": {
+                "message_id": 1,
+                "from": {
+                  "id": 1087968824,
+                  "is_bot": true,
+                  "first_name": "Group",
+                  "username": "GroupAnonymousBot"
+                },
+                "sender_chat": {
+                  "id": 42,
+                  "title": "MigratedToSupergroupTest",
+                  "type": "supergroup"
+                },
+                "chat": {
+                  "id": 42,
+                  "title": "MigratedToSupergroupTest",
+                  "type": "supergroup"
+                },
+                "date": 1639955462,
+                "migrate_from_chat_id": 57005
+              }
+            }
+        """.trimIndent()
+        val update = TestsJsonFormat.decodeFromString(UpdateDeserializationStrategy, payload)
+        val message = update.asMessageUpdate() ?: fail("update should be of MessageUpdate subtype")
+        val data = message.data.asSupergroupEventMessage() ?: fail("message should be of SupergroupEventMessage subtype")
+        val event = data.chatEvent.asMigratedToSupergroup() ?: fail("event should be of SupergroupChatCreated subtype")
+
+        assertEquals(ChatId(57005), event.migratedFrom)
+    }
+}

--- a/tgbotapi.utils/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/utils/ClassCasts.kt
+++ b/tgbotapi.utils/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/utils/ClassCasts.kt
@@ -3082,6 +3082,15 @@ inline fun ChatEvent.asSupergroupChatCreated(): SupergroupChatCreated? = this as
 inline fun ChatEvent.requireSupergroupChatCreated(): SupergroupChatCreated = this as SupergroupChatCreated
 
 @PreviewFeature
+inline fun <T> ChatEvent.whenMigratedToSupergroup(block: (MigratedToSupergroup) -> T) = asMigratedToSupergroup() ?.let(block)
+
+@PreviewFeature
+inline fun ChatEvent.asMigratedToSupergroup(): MigratedToSupergroup? = this as? MigratedToSupergroup
+
+@PreviewFeature
+inline fun ChatEvent.requireMigratedToSupergroup(): MigratedToSupergroup = this as MigratedToSupergroup
+
+@PreviewFeature
 inline fun <T> ChatEvent.whenChannelEvent(block: (ChannelEvent) -> T) = asChannelEvent() ?.let(block)
 
 @PreviewFeature


### PR DESCRIPTION
Although there is no difference between regular groups and supergroups in Telegram clients anymore, those types still exist somewhere in the guts of the Telegram. Groups are converted to supergroups [automatically](https://www.reddit.com/r/Telegram/comments/an9lqa/comment/efscq3b/?utm_source=reddit&utm_medium=web2x&context=3). One way to do that, is, for example, to make the history available for new group members.

When it happens — a group is converted to a supergroup —  a bunch of updates sent to bots in the group. All of them are parsed correctly by the library, except one. The migration event itself.

It's payload is something like:

```json
{
    "update_id": 626042422,
    "message": {
        "message_id": 1,
        "from": {
            "id": 1087968824,
            "is_bot": true,
            "first_name": "Group",
            "username": "GroupAnonymousBot"
        },
        "sender_chat": {
            "id": -1001241958329,
            "title": "Tyzenhaus Test",
            "type": "supergroup"
        },
        "chat": {
            "id": -1001241958329,
            "title": "Tyzenhaus Test",
            "type": "supergroup"
        },
        "date": 1639955462,
        "migrate_from_chat_id": -720793082
    }
}
```
And currently it is parsed to an `UnknownUpdate`. This PR adds a new event type: `MigratedToSupergroup`.