### PR TITLE
Add `hasCommands` / `hasNoCommands` extensions on `CommonMessage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # TelegramBotAPI changelog
 
+## 3.4.0
+
+* `Utils`:
+    * New extensions on `CommonMessage`: `hasCommands` and `hasNoCommands`. Useful for the `initialFilter` parameter in behaviour builder triggers.
+
 ## 3.3.0
 
 **THIS VERSION CONTAINS UPGRADE KOTLIN (AND ALL RELATED LIBRARIES) UP TO 1.7.20**

--- a/tgbotapi.utils/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/utils/updates/MessageFilters.kt
+++ b/tgbotapi.utils/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/utils/updates/MessageFilters.kt
@@ -1,0 +1,42 @@
+package dev.inmo.tgbotapi.extensions.utils.updates
+
+import dev.inmo.tgbotapi.extensions.utils.botCommandTextSourceOrNull
+import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
+import dev.inmo.tgbotapi.types.message.content.TextContent
+
+/**
+ * A predicate to test whether a message contains any commands in its body.
+ * Use it as the `initialFilter` parameter in behaviour builder triggers.
+ * E.g.
+ *
+ * ```kotlin
+ * onContentMessage(
+ *     initialFilter = CommonMessage<MessageContent>::hasCommands
+ * ) {
+ *     // the message contains at least one command here
+ * }
+ * ```
+ *
+ * @return true if this [CommonMessage] contains any commands. False otherwise.
+ * @see hasNoCommands
+ */
+fun CommonMessage<*>.hasCommands(): Boolean =
+    (this.content as? TextContent)?.textSources?.any { it.botCommandTextSourceOrNull() != null } ?: false
+
+/**
+ * A predicate to test whether a message contains any commands in its body.
+ * Use it as the `initialFilter` parameter in behaviour builder triggers.
+ * E.g.
+ *
+ * ```kotlin
+ * onContentMessage(
+ *     initialFilter = CommonMessage<MessageContent>::hasNoCommands
+ * ) {
+ *     // the message contains no commands here
+ * }
+ * ```
+ *
+ * @return true if this [CommonMessage] does not contain any commands. False otherwise.
+ * @see hasCommands
+ */
+fun CommonMessage<*>.hasNoCommands(): Boolean = !this.hasCommands()


### PR DESCRIPTION
These extensions are meant to be used as arguments to the `initialFilter` parameter in behaviour builder triggers.
