### PR TITLE
Fix onPreCheckoutQuery will not handle queries if OrderInfo contains non-nullable value only in one field

### DIFF
--- a/tgbotapi.utils/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/utils/JsonFormat.kt
+++ b/tgbotapi.utils/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/utils/JsonFormat.kt
@@ -9,4 +9,5 @@ internal val nonstrictJsonFormat = Json {
     allowSpecialFloatingPointValues = true
     useArrayPolymorphism = true
     encodeDefaults = true
+    explicitNulls = false
 }


### PR DESCRIPTION
Added `explicitNulls = false` to `nonstrictJsonFormat`

Fixes #917 