### PR TITLE
Detect Too Many Requests case-insensitively (closes #1008)

### DIFF
--- a/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/bot/exceptions/RequestException.kt
+++ b/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/bot/exceptions/RequestException.kt
@@ -22,7 +22,7 @@ fun newRequestException(
         description == "Unauthorized" -> UnauthorizedException(response, plainAnswer, message, cause)
         description.contains("PHOTO_INVALID_DIMENSIONS") -> InvalidPhotoDimensionsException(response, plainAnswer, message, cause)
         description.contains("wrong file identifier") -> WrongFileIdentifierException(response, plainAnswer, message, cause)
-        description.contains("Too Many Requests") -> TooMuchRequestsException(
+        description.contains("Too Many Requests", ignoreCase = true) -> TooMuchRequestsException(
             (response.parameters ?.error as? RetryAfterError) ?: RetryAfterError(60, DateTime.now().unixMillisLong),
             response,
             plainAnswer,

--- a/tgbotapi.core/src/commonTest/kotlin/dev/inmo/tgbotapi/bot/exceptions/NewRequestExceptionTests.kt
+++ b/tgbotapi.core/src/commonTest/kotlin/dev/inmo/tgbotapi/bot/exceptions/NewRequestExceptionTests.kt
@@ -1,0 +1,39 @@
+package dev.inmo.tgbotapi.bot.exceptions
+
+import dev.inmo.tgbotapi.types.Response
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+/**
+ * Regression tests for https://github.com/InsanusMokrassar/TelegramBotAPI/issues/1008 —
+ * Telegram's "Too Many Requests" response is case-inconsistent (both
+ * `Too Many Requests` and `too Many Requests` have been observed), so the
+ * description match must be case-insensitive.
+ */
+class NewRequestExceptionTests {
+    private fun buildException(description: String) = newRequestException(
+        response = Response(ok = false, description = description, errorCode = 429),
+        plainAnswer = "{\"ok\":false}"
+    )
+
+    @Test
+    fun `TooMuchRequestsException is created for canonical casing`() {
+        assertIs<TooMuchRequestsException>(
+            buildException("Bad Request: Too Many Requests: retry after 8")
+        )
+    }
+
+    @Test
+    fun `TooMuchRequestsException is created for lowercase first-letter casing`() {
+        assertIs<TooMuchRequestsException>(
+            buildException("Bad Request: too Many Requests: retry after 8")
+        )
+    }
+
+    @Test
+    fun `TooMuchRequestsException is created for all-lowercase casing`() {
+        assertIs<TooMuchRequestsException>(
+            buildException("Bad Request: too many requests: retry after 8")
+        )
+    }
+}


### PR DESCRIPTION
Closes #1008.

### The bug

`newRequestException` in `RequestException.kt` checks for `"Too Many Requests"` with a case-sensitive `contains(...)`. Telegram has been observed to return `"Bad Request: too Many Requests: retry after N"` (lowercase leading `t`) — the reporter captured this verbatim. When that happens, no `TooMuchRequestsException` is thrown and the caller can't distinguish rate-limit responses from generic `CommonRequestException`.

### The fix

Single-line change: `contains("Too Many Requests", ignoreCase = true)`.

### Tests

Added `NewRequestExceptionTests` with three cases under `tgbotapi.core/src/commonTest`:

- canonical `"Too Many Requests"` casing
- reporter-observed `"too Many Requests"` (lowercase leading `t`)
- `"too many requests"` all-lowercase

All pass under `./gradlew :tgbotapi.core:jvmTest` (3 new + existing tests). Full `jvmTest` target is green on my machine (JDK 21).

### Note

The reporter's second comment on the issue flags a separate concern — Telegram's response in this case omits `parameters.retry_after`, so the fallback `RetryAfterError(60, ...)` always kicks in. I've intentionally left that alone to keep this PR scoped to the case-sensitivity fix; happy to open a follow-up if you'd like the retry-after parsing improved too (e.g. scraping `retry after N` out of the description text).