### PR TITLE
Recognize new Telegram wording of the missing reply error

### DIFF
--- a/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/bot/exceptions/RequestException.kt
+++ b/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/bot/exceptions/RequestException.kt
@@ -17,7 +17,7 @@ fun newRequestException(
     cause: Throwable? = null
 ) = response.description ?.let { description ->
     when {
-        description == "Bad Request: reply message not found" || description == "Bad Request: replied message not found" -> ReplyMessageNotFoundException(response, plainAnswer, message, cause)
+        description == "Bad Request: reply message not found" || description == "Bad Request: replied message not found" || description == "Bad Request: message to be replied not found" -> ReplyMessageNotFoundException(response, plainAnswer, message, cause)
         description == "Bad Request: message to edit not found" -> MessageToEditNotFoundException(response, plainAnswer, message, cause)
         description.contains("Bad Request: message is not modified") -> MessageIsNotModifiedException(response, plainAnswer, message, cause)
         description == "Unauthorized" -> UnauthorizedException(response, plainAnswer, message, cause)

--- a/tgbotapi.core/src/commonTest/kotlin/dev/inmo/tgbotapi/bot/exceptions/NewRequestExceptionTests.kt
+++ b/tgbotapi.core/src/commonTest/kotlin/dev/inmo/tgbotapi/bot/exceptions/NewRequestExceptionTests.kt
@@ -5,14 +5,20 @@ import kotlin.test.Test
 import kotlin.test.assertIs
 
 /**
- * Regression tests for https://github.com/InsanusMokrassar/TelegramBotAPI/issues/1008 —
+ * Regression tests for [newRequestException] description matching.
+ *
+ * https://github.com/InsanusMokrassar/TelegramBotAPI/issues/1008 —
  * Telegram's "Too Many Requests" response is case-inconsistent (both
  * `Too Many Requests` and `too Many Requests` have been observed), so the
  * description match must be case-insensitive.
+ *
+ * Telegram has also changed the wording of the missing reply error over time:
+ * `reply message not found`, `replied message not found` and, in current Bot API
+ * versions, `message to be replied not found` should all be recognized.
  */
 class NewRequestExceptionTests {
-    private fun buildException(description: String) = newRequestException(
-        response = Response(ok = false, description = description, errorCode = 429),
+    private fun buildException(description: String, errorCode: Int = 429) = newRequestException(
+        response = Response(ok = false, description = description, errorCode = errorCode),
         plainAnswer = "{\"ok\":false}"
     )
 
@@ -34,6 +40,27 @@ class NewRequestExceptionTests {
     fun tooMuchRequestsExceptionIsCreatedForAllLowercaseCasing() {
         assertIs<TooMuchRequestsException>(
             buildException("Bad Request: too many requests: retry after 8")
+        )
+    }
+
+    @Test
+    fun replyMessageNotFoundExceptionIsCreatedForLegacyReplyWording() {
+        assertIs<ReplyMessageNotFoundException>(
+            buildException("Bad Request: reply message not found", errorCode = 400)
+        )
+    }
+
+    @Test
+    fun replyMessageNotFoundExceptionIsCreatedForLegacyRepliedWording() {
+        assertIs<ReplyMessageNotFoundException>(
+            buildException("Bad Request: replied message not found", errorCode = 400)
+        )
+    }
+
+    @Test
+    fun replyMessageNotFoundExceptionIsCreatedForCurrentWording() {
+        assertIs<ReplyMessageNotFoundException>(
+            buildException("Bad Request: message to be replied not found", errorCode = 400)
         )
     }
 }


### PR DESCRIPTION
Telegram now returns a new wording for the missing reply error:

```json
{"ok":false,"error_code":400,"description":"Bad Request: message to be replied not found"}
```

`newRequestException` only knows the older wordings (`Bad Request: reply message not found`, `Bad Request: replied message not found`), so this response falls through to `CommonRequestException` instead of `ReplyMessageNotFoundException`, and code that catches `ReplyMessageNotFoundException` to retry without the reply anchor never gets a chance to run.

I hit this in a supergroup when my bot replied to a message that had just been deleted by its author (June 2026, Bot API 10.0).

The PR adds the new description to the existing check and extends `NewRequestExceptionTests` to cover all three wordings. I also generalized the doc comment of that test class a bit, since it now covers more than the issue 1008 case.

Tested with `:tgbotapi.core:jvmTest`.